### PR TITLE
Added option to choose velocity instead of speed

### DIFF
--- a/src/Gauge.as
+++ b/src/Gauge.as
@@ -15,8 +15,13 @@ class Gauge
 
     void InternalRender(CSceneVehicleVisState@ vis)
     {
+        if (PluginSettings::ShowVelocity) {
+            m_speed = vis.WorldVel.Length() * 3.6f;
+        } else {
+            m_speed = vis.FrontSpeed * 3.6f;
+        }
+
         m_rpm = VehicleState::GetRPM(vis);
-        m_speed = vis.FrontSpeed * 3.6f;
         m_gear = vis.CurGear;
 
         if (vis.CurGear == 0)

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -27,6 +27,9 @@ namespace PluginSettings
     [Setting name="Size" category="General"]
     vec2 Size = vec2(350, 350);
 
+    [Setting name="Use velocity instead of speed (useful for ice)" category="General"]
+    bool ShowVelocity = false;
+
     [SettingsTab name="Theme Settings"]
     void RenderThemeSettingsTab()
     {


### PR DESCRIPTION
Added an option to use vis.WorldVel.Length() instead of FrontSpeed. This is especially useful on ice, as it'll show the car's true speed even when in an iceslide. 

No strong opinions on the settings text - that was the best I could come up with. 